### PR TITLE
Psycopg2 and Additional Run Command/Script Functions

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 '''
 Module to provide Postgres compatibility to salt.
 
@@ -34,17 +35,23 @@ Module to provide Postgres compatibility to salt.
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
 import datetime
-import logging
 import hashlib
+import io
+import logging
 import os
-import re
 import pipes
+import re
 import tempfile
 try:
     import csv
     HAS_CSV = True
 except ImportError:
     HAS_CSV = False
+try:
+    import psycopg2
+    HAS_PSYCOPG = True
+except ImportError:
+    HAS_PSYCOPG = False
 
 # Import salt libs
 import salt.utils.files
@@ -113,18 +120,24 @@ _PRIVILEGE_TYPE_MAP = {
 }
 
 
+class PsqlArgParsingError(Exception):
+    pass
+
+
 def __virtual__():
     '''
     Only load this module if the psql bin exist.
     initdb bin might also be used, but its presence will be detected on runtime.
     '''
-    utils = ['psql']
     if not HAS_CSV:
-        return False
-    for util in utils:
-        if not salt.utils.path.which(util):
-            if not _find_pg_binary(util):
-                return (False, '{0} was not found'.format(util))
+        return (False, 'The postgres execution module failed to load: '
+                       'the csv library is not available')
+
+    # Require at least one of psql and psycopg2
+    if not salt.utils.path.which('psql') and not _find_pg_binary('psql') and not HAS_PSYCOPG:
+        return (False, 'The postgres execution module failed to load: '
+                       'psql was not found and psycopg2 is not installed')
+
     return True
 
 
@@ -260,17 +273,23 @@ def version(user=None, host=None, port=None, maintenance_db=None,
 
         salt '*' postgres.version
     '''
+
     query = 'SELECT setting FROM pg_catalog.pg_settings ' \
             'WHERE name = \'server_version\''
-    cmd = _psql_cmd('-c', query,
-                    '-t',
-                    host=host,
-                    user=user,
-                    port=port,
-                    maintenance_db=maintenance_db,
-                    password=password)
-    ret = _run_psql(
-        cmd, runas=runas, password=password, host=host, port=port, user=user)
+
+    if HAS_PSYCOPG:
+        ret = _psycopg_run_command(query, db_name=maintenance_db, host=host, port=port, user=user, password=password)
+
+    else:
+        cmd = _psql_cmd('-c', query,
+                        '-t',
+                        host=host,
+                        user=user,
+                        port=port,
+                        maintenance_db=maintenance_db,
+                        password=password)
+        ret = _run_psql(
+            cmd, runas=runas, password=password, host=host, port=port, user=user)
 
     for line in salt.utils.itertools.split(ret['stdout'], '\n'):
         # Just return the first line
@@ -319,6 +338,13 @@ def _connection_defaults(user=None, host=None, port=None, maintenance_db=None,
     if password is None:
         password = __salt__['config.option']('postgres.pass')
 
+    # Default the values for psycopg2 if not set by salt config
+    if HAS_PSYCOPG:
+        if not user:
+            user = 'postgres'
+        if not maintenance_db:
+            maintenance_db = 'postgres'
+
     return (user, host, port, maintenance_db, password)
 
 
@@ -334,7 +360,9 @@ def _psql_cmd(*args, **kwargs):
         kwargs.get('host'),
         kwargs.get('port'),
         kwargs.get('maintenance_db'),
-        kwargs.get('password'))
+        kwargs.get('password')
+    )
+
     _PSQL_BIN = _find_pg_binary('psql')
     cmd = [_PSQL_BIN,
            '--no-align',
@@ -354,6 +382,31 @@ def _psql_cmd(*args, **kwargs):
     return cmd
 
 
+def _parse_psql_flags_for_cmd(cmd):
+    it = iter(cmd)
+    for x in it:
+        # Execute command - return the command
+        if x == '-c':
+            return next(it)
+
+        # Execute script - return the script file contents
+        elif x == '-f':
+            with salt.utils.fopen(next(it)) as f:
+                script_file_data = f.read()
+            return script_file_data
+
+        # Ignore set parameter flags
+        elif x == '-v':
+            y = next(it)
+            log.debug("Ignoring psql command line flag: -v {0}".format(y))
+
+        # Raise error for unhandled flag
+        else:
+            raise PsqlArgParsingError("Unable to parse unknown flag: {0}".format(x))
+
+    raise SaltInvocationError("No command or file was given to psql in {0}".format(cmd))
+
+
 def _psql_prepare_and_run(cmd,
                           host=None,
                           port=None,
@@ -361,6 +414,20 @@ def _psql_prepare_and_run(cmd,
                           password=None,
                           runas=None,
                           user=None):
+
+    if HAS_PSYCOPG:
+        try:
+            cmd = _parse_psql_flags_for_cmd(cmd)
+            return _psycopg_run_command(cmd,
+                                        host=host,
+                                        port=port,
+                                        db_name=maintenance_db,
+                                        password=password,
+                                        user=user)
+        except PsqlArgParsingError:
+            # If parsing the arguments in cmd failed, fall back on psql
+            pass
+
     rcmd = _psql_cmd(
         host=host, user=user, port=port,
         maintenance_db=maintenance_db, password=password,
@@ -428,6 +495,7 @@ def psql_query(query, user=None, host=None, port=None, maintenance_db=None,
                                    host=host, user=user, port=port,
                                    maintenance_db=maintenance_db,
                                    password=password)
+
     if cmdret['retcode'] > 0:
         return ret
 
@@ -604,10 +672,14 @@ def db_alter(name, user=None, host=None, port=None, maintenance_db=None,
                 name, tablespace
             ))
         for query in queries:
-            ret = _psql_prepare_and_run(['-c', query],
-                                        user=user, host=host, port=port,
-                                        maintenance_db=maintenance_db,
-                                        password=password, runas=runas)
+            if HAS_PSYCOPG:
+                ret = _psycopg_run_command(query, user=user, host=host, port=port,
+                                           db_name=maintenance_db, password=password)
+            else:
+                ret = _psql_prepare_and_run(['-c', query],
+                                            user=user, host=host, port=port,
+                                            maintenance_db=maintenance_db,
+                                            password=password, runas=runas)
 
     if ret['retcode'] != 0:
         return False
@@ -3187,3 +3259,194 @@ def datadir_exists(name):
     _config_file = os.path.join(name, 'postgresql.conf')
 
     return os.path.isfile(_version_file) and os.path.isfile(_config_file)
+
+
+def _psycopg_get_cursor(db_name=None, host=None, port=None, user=None, password=None):
+    """
+    Get back a psycopg2 cursor for the connection to the db specified.
+    - Connections are stored in the __context__ dictionary to persist across usage of this module.
+    - Will open a new connection to the db if it cannot find one cached.
+    - The cursor returned is in autocommit mode and first sets the datestyle to a specific format.
+
+    Returns None and does not cache if the connection failed.
+    """
+    (user, host, port, db_name, password) = _connection_defaults(maintenance_db=db_name,
+                                                                 host=host, port=port,
+                                                                 user=user, password=password)
+
+    # Create connection and store in context if not already there
+    db_conn_key = _psycopg_get_db_conn_key(db_name=db_name, host=host, port=port, user=user)
+
+    if db_conn_key not in __context__:
+        try:
+            conn = psycopg2.connect(dbname=db_name, user=user, password=password, host=host,
+                                    port=port)
+            conn.set_session(autocommit=True)
+
+            # Set the datestyle for the connection
+            cur = conn.cursor()
+            cur.execute("SET DateStyle='ISO,MDY'")
+
+        except psycopg2.OperationalError:
+            return None
+
+        __context__[db_conn_key] = conn
+
+    conn = __context__[db_conn_key]
+    cur = conn.cursor()
+
+    return cur
+
+
+def _psycopg_get_db_conn_key(db_name, host, port, user):
+    return "db=" + str(db_name) + ",user=" + str(user) + ",host=" + str(host) + ",port=" + str(port)
+
+
+def _psycopg_run_command(cmd, db_name=None, host=None, port=None, user=None, password=None):
+    # Copy commands must be handled by specific psycopg2 methods
+    if re.match('COPY.+', cmd):
+        return _psycopg_run_copy(cmd, db_name=db_name, host=host, port=port,
+                                 user=user, password=password)
+
+    cur = _psycopg_get_cursor(db_name=db_name, host=host, port=port, user=user, password=password)
+    if cur is None:
+        return {'retcode': -1, 'stdout': 'Failed to connect to db'}
+
+    try:
+        cur.execute(cmd)
+        success = 0
+    except psycopg2.Error as e:
+        log.error(str(e))
+        success = -1
+
+    # See if there were any results in case of query
+    res = cur.statusmessage
+    if "SELECT" in res:
+        res = _psycopg_format_as_psql_output(cur.fetchall())
+
+    return {'retcode': success, 'stdout': res}
+
+
+def _psycopg_run_copy(cmd, db_name=None, host=None, port=None, user=None, password=None):
+    # Only one specific format of copy command is currently supported
+    if re.match('COPY.+TO STDOUT WITH.+', cmd) is None:
+        log.error('Support for this COPY query is not implemented. See psycopg2 docs for how to.')
+        return {'retcode': -1}
+
+    cur = _psycopg_get_cursor(db_name=db_name, host=host, port=port, user=user, password=password)
+    if cur is None:
+        return {'retcode': -1, 'stdout': 'Failed to connect to db'}
+
+    # Create in memory file to copy results to
+    tmp_file = io.StringIO()
+    try:
+        cur.copy_expert(cmd, tmp_file)
+        success = 0
+    except psycopg2.Error as e:
+        log.error(str(e))
+        success = -1
+
+    res = tmp_file.getvalue()
+    tmp_file.close()
+
+    return {'retcode': success, 'stdout': res}
+
+
+def _psycopg_format_as_psql_output(rows):
+    """
+    Format the output from a psycopg2 fetch (a list of rows) as if it were returned from the
+    psql command line. THIS ONLY WORKS FOR A LIMITED NUMBER OF CASES.
+    """
+    output = ''
+    if len(rows) > 0:
+        if rows[0] == (True,):
+            output = "exists\n"
+            output += len(rows) * "t\n"
+
+        elif rows[0] == (False,):
+            output = "exists\n"
+            output += len(rows) * "f\n"
+
+        else:
+            output = 'val\n'
+            for row in rows:
+                output += row[0]
+                output += "\n"
+
+    # Append the number of rows fetched
+    num_rows = len(rows)
+    row_or_rows = ' row' if num_rows == 1 else ' rows'
+    footer = "(" + str(num_rows) + row_or_rows + ")"
+
+    return output + footer
+
+
+# Running general sql commands
+
+def run_command(cmd, dbname=None, host=None, port=None,
+                user=None, password=None, runas=None):
+    """
+    Run a command on a postgres database, using psycopg2 if installed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' postgres_ext.run_command 'create table foo()'
+
+    cmd
+        The single sql statement to run
+
+    dbname
+        The database that we run the script against
+
+    Other args are the same as the configuration
+
+    """
+    return _psql_prepare_and_run(
+        ['-c', cmd],
+        maintenance_db=dbname,
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        runas=runas,
+    )
+
+
+def run_script(source, saltenv='base', dbname=None, host=None, port=None,
+               user=None, password=None, runas=None):
+    """
+    Run a script on a postgres database, using psycopg2 if installed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' postgres_ext.run_script salt://script.sql
+
+    source
+        The script to run. Expects a salt URI at the moment
+
+    saltenv
+        The environment to look for the script in (defaults to base)
+
+    dbname
+        The database that we run the script against
+
+    Other args are the same as the configuration
+
+    """
+    script_file = __salt__['cp.cache_file'](source, saltenv=saltenv)
+    with salt.utils.fopen(script_file) as f:
+        script_file_data = f.read()
+
+    return _psql_prepare_and_run(
+            ['-c', script_file_data],
+            maintenance_db=dbname,
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            runas=runas,
+    )

--- a/tests/unit/modules/postgres_with_psycopg2_test.py
+++ b/tests/unit/modules/postgres_with_psycopg2_test.py
@@ -1,0 +1,1356 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from mock import call
+import re
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, Mock, patch
+
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.modules import postgres
+from salt.exceptions import SaltInvocationError
+
+postgres.__grains__ = None  # in order to stub it w/patch below
+postgres.__salt__ = None  # in order to stub it w/patch below
+postgres.__context__ = {}  # in order to stub it w/patch below
+
+# region Test Data
+test_list_db_csv = (
+    'Name,Owner,Encoding,Collate,Ctype,Access privileges,Tablespace\n'
+    'template1,postgres,LATIN1,en_US,en_US'
+    ',"{=c/postgres,postgres=CTc/postgres}",pg_default\n'
+    'template0,postgres,LATIN1,en_US,en_US'
+    ',"{=c/postgres,postgres=CTc/postgres}",pg_default\n'
+    'postgres,postgres,LATIN1,en_US,en_US,,pg_default\n'
+    'test_db,postgres,LATIN1,en_US,en_US,,pg_default'
+)
+
+test_list_schema_csv = (
+    'name,owner,acl\n'
+    'public,postgres,"{postgres=UC/postgres,=UC/postgres}"\n'
+    'pg_toast,postgres,""'
+)
+
+test_list_language_csv = (
+    'Name\n'
+    'internal\n'
+    'c\n'
+    'sql\n'
+    'plpgsql\n'
+)
+
+test_privileges_list_table_csv = (
+    'name\n'
+    '"{baruwatest=arwdDxt/baruwatest,bayestest=arwd/baruwatest,baruwa=a*r*w*d*D*x*t*/baruwatest}"\n'
+)
+
+test_privileges_list_group_csv = (
+    'rolname,admin_option\n'
+    'baruwa,f\n'
+    'baruwatest2,t\n'
+    'baruwatest,f\n'
+)
+# endregion
+
+if NO_MOCK is False:
+    SALT_STUB = {
+        'config.option': Mock(),
+        'cmd.run_all': Mock(),
+        'file.chown': Mock(),
+        'file.remove': Mock(),
+    }
+else:
+    SALT_STUB = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch.multiple(postgres,
+                __grains__={'os_family': 'Linux'},
+                __salt__=SALT_STUB,
+                __context__={})
+@patch('salt.utils.which', Mock(return_value='/usr/bin/pgsql'))
+class PostgresTestCase(TestCase):
+
+    def test_psycopg_found(self):
+        self.assertTrue(postgres.HAS_PSYCOPG)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    def test_db_alter(self):
+        postgres.db_alter('dbname',
+                          user='testuser',
+                          host='testhost',
+                          port='testport',
+                          maintenance_db='maint_db',
+                          password='foo',
+                          tablespace='testspace',
+                          owner='otheruser',
+                          runas='foo')
+        postgres._psycopg_run_command.assert_has_calls([
+            call('ALTER DATABASE "dbname" OWNER TO "otheruser"',
+                 db_name='maint_db',
+                 host='testhost',
+                 user='testuser',
+                 password='foo',
+                 port='testport'),
+            call('ALTER DATABASE "dbname" SET TABLESPACE "testspace"',
+                 db_name='maint_db',
+                 host='testhost',
+                 user='testuser',
+                 password='foo',
+                 port='testport')
+        ])
+
+    @patch('salt.modules.postgres.owner_to',
+           Mock(return_value={'retcode': None}))
+    def test_db_alter_owner_recurse(self):
+        postgres.db_alter('dbname',
+                          user='testuser',
+                          host='testhost',
+                          port='testport',
+                          maintenance_db='maint_db',
+                          password='foo',
+                          tablespace='testspace',
+                          owner='otheruser',
+                          owner_recurse=True,
+                          runas='foo')
+        postgres.owner_to.assert_called_once_with('dbname',
+                                                  'otheruser',
+                                                  user='testuser',
+                                                  host='testhost',
+                                                  port='testport',
+                                                  password='foo',
+                                                  runas='foo')
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    def test_db_create(self):
+        postgres.db_create(
+            'dbname',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            tablespace='testspace',
+            owner='otheruser',
+            runas='foo'
+        )
+
+        postgres._psycopg_run_command.assert_called_once_with(
+            'CREATE DATABASE "dbname" WITH TABLESPACE = "testspace" OWNER = "otheruser"',
+            db_name='maint_db', host='testhost', port='testport',
+            user='testuser', password='foo'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    def test_db_create_empty_string_param(self):
+        postgres.db_create('dbname', lc_collate='', encoding='utf8',
+                           user='testuser', host='testhost', port=1234,
+                           maintenance_db='maint_db', password='foo')
+
+        postgres._psycopg_run_command.assert_called_once_with(
+            'CREATE DATABASE "dbname" WITH ENCODING = \'utf8\' LC_COLLATE = \'\'',
+            db_name='maint_db', host='testhost', port=1234,
+            user='testuser', password='foo'
+        )
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    def test_db_create_with_trivial_sql_injection(self):
+        self.assertRaises(
+            SaltInvocationError,
+            postgres.db_create,
+            'dbname', lc_collate="foo' ENCODING='utf8"
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_list_db_csv}))
+    def test_db_exists(self):
+        ret = postgres.db_exists(
+            'test_db',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            runas='foo'
+        )
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_list_db_csv}))
+    def test_db_list(self):
+        ret = postgres.db_list(
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            runas='foo'
+        )
+        self.assertDictEqual(ret, {
+            'test_db': {'Encoding': 'LATIN1', 'Ctype': 'en_US',
+                        'Tablespace': 'pg_default', 'Collate': 'en_US',
+                        'Owner': 'postgres', 'Access privileges': ''},
+            'template1': {'Encoding': 'LATIN1', 'Ctype': 'en_US',
+                          'Tablespace': 'pg_default', 'Collate': 'en_US',
+                          'Owner': 'postgres',
+                          'Access privileges': (
+                              '{=c/postgres,postgres=CTc/postgres}'
+                          )},
+            'template0': {'Encoding': 'LATIN1', 'Ctype': 'en_US',
+                          'Tablespace': 'pg_default', 'Collate': 'en_US',
+                          'Owner': 'postgres',
+                          'Access privileges': (
+                              '{=c/postgres,postgres=CTc/postgres}'
+                          )},
+            'postgres': {'Encoding': 'LATIN1', 'Ctype': 'en_US',
+                         'Tablespace': 'pg_default', 'Collate': 'en_US',
+                         'Owner': 'postgres', 'Access privileges': ''}
+        })
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    def test_db_remove(self):
+        postgres.db_remove(
+            'test_db',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            runas='foo'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+             'DROP DATABASE "test_db"',
+            db_name='maint_db', host='testhost', port='testport',
+            user='testuser', password='foo'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.user_exists',
+           Mock(return_value=False))
+    def test_group_create(self):
+        postgres.group_create(
+            'testgroup',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            createdb=False,
+            createuser=False,
+            encrypted=False,
+            superuser=False,
+            replication=False,
+            rolepassword='testrolepass',
+            groups='testgroup',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query#
+        self.assertTrue(postgres._psycopg_run_command.call_args[0][0].startswith('CREATE ROLE'))
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.user_exists',
+           Mock(return_value=True))
+    def test_group_remove(self):
+        postgres.group_remove(
+            'testgroup',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            runas='foo'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'DROP ROLE "testgroup"',
+            db_name='maint_db', host='testhost', port='testport',
+            user='testuser', password='foo'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
+    def test_group_update(self):
+        postgres.group_update(
+            'testgroup',
+            user='"testuser"',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='foo',
+            createdb=False,
+            createuser=False,
+            encrypted=False,
+            replication=False,
+            rolepassword='test_role_pass',
+            groups='testgroup',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        self.assertTrue(
+            re.match(
+                'ALTER.* "testgroup" .* UNENCRYPTED PASSWORD',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.user_exists',
+           Mock(return_value=False))
+    def test_user_create(self):
+        postgres.user_create(
+            'testuser',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_test',
+            password='test_pass',
+            login=True,
+            createdb=False,
+            createroles=False,
+            createuser=False,
+            encrypted=False,
+            superuser=False,
+            replication=False,
+            rolepassword='test_role_pass',
+            groups='test_groups',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        call = postgres._psycopg_run_command.call_args[0][0]
+        self.assertTrue(re.match('CREATE ROLE "testuser"', call))
+        for i in (
+            'INHERIT NOCREATEDB NOCREATEROLE '
+            'NOSUPERUSER NOREPLICATION LOGIN UNENCRYPTED PASSWORD'
+        ).split():
+            self.assertTrue(i in call, '{0} not in {1}'.format(i, call))
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.version',
+           Mock(return_value='9.1'))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {
+                   'name': 'test_user',
+                   'superuser': 't',
+                   'inherits privileges': 't',
+                   'can create roles': 't',
+                   'can create databases': 't',
+                   'can update system catalogs': 't',
+                   'can login': 't',
+                   'replication': None,
+                   'password': 'test_password',
+                   'connections': '-1',
+                   'defaults variables': None
+               }]))
+    def test_user_exists(self):
+        ret = postgres.user_exists(
+            'test_user',
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='maint_db',
+            password='test_password',
+            runas='foo'
+        )
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.version',
+           Mock(return_value='9.1'))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {
+                   'name': 'test_user',
+                   'superuser': 't',
+                   'inherits privileges': 't',
+                   'can create roles': 't',
+                   'can create databases': 't',
+                   'can update system catalogs': 't',
+                   'can login': 't',
+                   'replication': None,
+                   'connections': '-1',
+                   'defaults variables': None
+               }]))
+    def test_user_list(self):
+        ret = postgres.user_list(
+            'test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='maint_db',
+            password='test_password',
+            runas='foo'
+        )
+
+        self.assertDictEqual(ret, {
+            'test_user': {'superuser': True,
+                          'defaults variables': None,
+                          'can create databases': True,
+                          'can create roles': True,
+                          'connections': None,
+                          'replication': None,
+                          'expiry time': None,
+                          'can login': True,
+                          'can update system catalogs': True,
+                          'groups': [],
+                          'inherits privileges': True}
+        })
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.version',
+           Mock(return_value='9.1'))
+    @patch('salt.modules.postgres.user_exists',
+           Mock(return_value=True))
+    def test_user_remove(self):
+        postgres.user_remove(
+            'testuser',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            maintenance_db='maint_db',
+            password='testpassword',
+            runas='foo'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'DROP ROLE "testuser"',
+            db_name='maint_db', host='testhost', port='testport',
+            user='testuser', password='testpassword'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
+    def test_user_update(self):
+        postgres.user_update(
+            'test_username',
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='test_maint',
+            password='test_pass',
+            createdb=False,
+            createroles=False,
+            createuser=False,
+            encrypted=False,
+            inherit=True,
+            login=True,
+            replication=False,
+            rolepassword='test_role_pass',
+            groups='test_groups',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        self.assertTrue(
+            re.match(
+                'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+                'NOCREATEROLE NOREPLICATION LOGIN '
+                'UNENCRYPTED PASSWORD [\'"]{0,5}test_role_pass[\'"]{0,5};'
+                ' GRANT "test_groups" TO "test_username"',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
+    def test_user_update2(self):
+        postgres.user_update(
+            'test_username',
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='test_maint',
+            password='test_pass',
+            createdb=False,
+            createroles=True,
+            createuser=False,
+            encrypted=False,
+            inherit=True,
+            login=True,
+            replication=False,
+            groups='test_groups',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        self.assertTrue(
+            re.match(
+                'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+                'CREATEROLE NOREPLICATION LOGIN;'
+                ' GRANT "test_groups" TO "test_username"',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
+    def test_user_update3(self):
+        postgres.user_update(
+            'test_username',
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='test_maint',
+            password='test_pass',
+            createdb=False,
+            createroles=True,
+            createuser=False,
+            encrypted=False,
+            inherit=True,
+            login=True,
+            rolepassword=False,
+            replication=False,
+            groups='test_groups',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        self.assertTrue(
+            re.match(
+                'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+                'CREATEROLE NOREPLICATION LOGIN NOPASSWORD;'
+                ' GRANT "test_groups" TO "test_username"',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
+    def test_user_update_encrypted_passwd(self):
+        postgres.user_update(
+            'test_username',
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='test_maint',
+            password='test_pass',
+            createdb=False,
+            createroles=True,
+            createuser=False,
+            encrypted=True,
+            inherit=True,
+            login=True,
+            rolepassword='foobar',
+            replication=False,
+            groups='test_groups',
+            runas='foo'
+        )
+        # call_args[0] contains the list of args, the first of which is the SQL query
+        self.assertTrue(
+            re.match(
+                'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+                'CREATEROLE NOREPLICATION LOGIN '
+                'ENCRYPTED PASSWORD '
+                '[\'"]{0,5}md531c27e68d3771c392b52102c01be1da1[\'"]{0,5}'
+                '; GRANT "test_groups" TO "test_username"',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': '9.1.9'}))
+    def test_version(self):
+        postgres.version(
+            user='test_user',
+            host='test_host',
+            port='test_port',
+            maintenance_db='test_maint',
+            password='test_pass',
+            runas='foo'
+        )
+        # postgres._psycopg_run_command is called with the query/command in
+        # its first argument.
+        self.assertTrue(
+            re.match(
+                'SELECT setting FROM pg_catalog.pg_settings',
+                postgres._psycopg_run_command.call_args[0][0]
+            )
+        )
+
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[{'extname': "foo", 'extversion': "1"}]))
+    def test_installed_extensions(self):
+        exts = postgres.installed_extensions()
+        self.assertEqual(
+            exts,
+            {'foo': {'extversion': '1', 'extname': 'foo'}}
+        )
+
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[{'name': "foo", 'default_version': "1"}]))
+    def test_available_extensions(self):
+        exts = postgres.available_extensions()
+        self.assertEqual(
+            exts,
+            {'foo': {'default_version': '1', 'name': 'foo'}}
+        )
+
+    @patch('salt.modules.postgres.installed_extensions',
+           Mock(side_effect=[{}, {}]))
+    @patch('salt.modules.postgres._psql_prepare_and_run',
+           Mock(return_value=None))
+    @patch('salt.modules.postgres.available_extensions',
+           Mock(return_value={'foo': {'default_version': '1', 'name': 'foo'}}))
+    def test_drop_extension2(self):
+        self.assertEqual(postgres.drop_extension('foo'), True)
+
+    @patch('salt.modules.postgres.installed_extensions',
+           Mock(side_effect=[{'foo': {'extversion': '1', 'extname': 'foo'}},
+                             {}]))
+    @patch('salt.modules.postgres._psql_prepare_and_run',
+           Mock(return_value=None))
+    @patch('salt.modules.postgres.available_extensions',
+           Mock(return_value={'foo': {'default_version': '1', 'name': 'foo'}}))
+    def test_drop_extension3(self):
+        self.assertEqual(postgres.drop_extension('foo'), True)
+
+    @patch('salt.modules.postgres.installed_extensions',
+           Mock(side_effect=[{'foo': {'extversion': '1', 'extname': 'foo'}},
+                             {'foo': {'extversion': '1', 'extname': 'foo'}}]))
+    @patch('salt.modules.postgres._psql_prepare_and_run',
+           Mock(return_value=None))
+    @patch('salt.modules.postgres.available_extensions',
+           Mock(return_value={'foo': {'default_version': '1', 'name': 'foo'}}))
+    def test_drop_extension1(self):
+        self.assertEqual(postgres.drop_extension('foo'), False)
+
+    @patch('salt.modules.postgres.installed_extensions',
+           Mock(return_value={
+               'foo': {'extversion': '0.8',
+                       'extrelocatable': 't',
+                       'schema_name': 'foo',
+                       'extname': 'foo'}},
+           ))
+    @patch('salt.modules.postgres.available_extensions',
+           Mock(return_value={'foo': {'default_version': '1.4',
+                                      'name': 'foo'}}))
+    def test_create_mtdata(self):
+        ret = postgres.create_metadata('foo', schema='bar', ext_version='1.4')
+        self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+        self.assertTrue(postgres._EXTENSION_TO_UPGRADE in ret)
+        self.assertTrue(postgres._EXTENSION_TO_MOVE in ret)
+        ret = postgres.create_metadata('foo', schema='foo', ext_version='0.4')
+        self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+        self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+        self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+        ret = postgres.create_metadata('foo')
+        self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+        self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+        self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+        ret = postgres.create_metadata('foobar')
+        self.assertTrue(postgres._EXTENSION_NOT_INSTALLED in ret)
+        self.assertFalse(postgres._EXTENSION_INSTALLED in ret)
+        self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+        self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+
+    @patch('salt.modules.postgres.create_metadata',
+           Mock(side_effect=[
+               # create succeeded
+               [postgres._EXTENSION_NOT_INSTALLED],
+               [postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_NOT_INSTALLED],
+               [postgres._EXTENSION_INSTALLED],
+               # create failed
+               [postgres._EXTENSION_NOT_INSTALLED],
+               [postgres._EXTENSION_NOT_INSTALLED],
+               # move+upgrade succeeded
+               [postgres._EXTENSION_TO_MOVE,
+                postgres._EXTENSION_TO_UPGRADE,
+                postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_INSTALLED],
+               # move succeeded
+               [postgres._EXTENSION_TO_MOVE,
+                postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_INSTALLED],
+               # upgrade succeeded
+               [postgres._EXTENSION_TO_UPGRADE,
+                postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_INSTALLED],
+               # upgrade failed
+               [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
+               # move failed
+               [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
+               [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
+           ]))
+    @patch('salt.modules.postgres._psql_prepare_and_run',
+           Mock(return_value=None))
+    @patch('salt.modules.postgres.available_extensions',
+           Mock(return_value={'foo': {'default_version': '1.4',
+                                      'name': 'foo'}}))
+    def test_create_extension_newerthan(self):
+        '''
+        scenario of creating upgrading extensions with possible schema and
+        version specifications
+        '''
+        self.assertTrue(postgres.create_extension('foo'))
+        self.assertTrue(re.match(
+            'CREATE EXTENSION IF NOT EXISTS "foo" ;',
+            postgres._psql_prepare_and_run.call_args[0][0][1]))
+        self.assertTrue(postgres.create_extension(
+            'foo', schema='a', ext_version='b', from_version='c'))
+        self.assertTrue(re.match(
+            'CREATE EXTENSION IF NOT EXISTS "foo" '
+            'WITH SCHEMA "a" VERSION b FROM c ;',
+            postgres._psql_prepare_and_run.call_args[0][0][1]))
+        self.assertFalse(postgres.create_extension('foo'))
+        ret = postgres.create_extension('foo', ext_version='a', schema='b')
+        self.assertTrue(ret)
+        self.assertTrue(re.match(
+            'ALTER EXTENSION "foo" SET SCHEMA "b";'
+            ' ALTER EXTENSION "foo" UPDATE TO a;',
+            postgres._psql_prepare_and_run.call_args[0][0][1]))
+        ret = postgres.create_extension('foo', ext_version='a', schema='b')
+        self.assertTrue(ret)
+        self.assertTrue(re.match(
+            'ALTER EXTENSION "foo" SET SCHEMA "b";',
+            postgres._psql_prepare_and_run.call_args[0][0][1]))
+        ret = postgres.create_extension('foo', ext_version='a', schema='b')
+        self.assertTrue(ret)
+        self.assertTrue(re.match(
+            'ALTER EXTENSION "foo" UPDATE TO a;',
+            postgres._psql_prepare_and_run.call_args[0][0][1]))
+        self.assertFalse(postgres.create_extension(
+            'foo', ext_version='a', schema='b'))
+        self.assertFalse(postgres.create_extension(
+            'foo', ext_version='a', schema='b'))
+
+    def test_encrypt_passwords(self):
+        self.assertEqual(
+            postgres._maybe_encrypt_password('foo', 'bar', False),
+            'bar'
+        )
+        self.assertEqual(
+            postgres._maybe_encrypt_password('foo', 'bar', True),
+            'md596948aad3fcae80c08a35c9b5958cd89'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_list_schema_csv}))
+    def test_schema_list(self):
+        ret = postgres.schema_list(
+            'maint_db',
+            db_user='testuser',
+            db_host='testhost',
+            db_port='testport',
+            db_password='foo'
+        )
+        self.assertDictEqual(ret, {
+            'public': {'acl': '{postgres=UC/postgres,=UC/postgres}',
+                       'owner': 'postgres'},
+            'pg_toast': {'acl': '', 'owner': 'postgres'}
+        })
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {
+                   'name': 'public',
+                   'acl': '{postgres=UC/postgres,=UC/postgres}',
+                   'owner': 'postgres'
+               }]))
+    def test_schema_exists(self):
+        ret = postgres.schema_exists(
+            'template1',
+            'public'
+        )
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {
+                   'name': 'public',
+                   'acl': '{postgres=UC/postgres,=UC/postgres}',
+                   'owner': 'postgres'
+               }]))
+    def test_schema_get(self):
+        ret = postgres.schema_get(
+            'template1',
+            'public'
+        )
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {
+                   'name': 'public',
+                   'acl': '{postgres=UC/postgres,=UC/postgres}',
+                   'owner': 'postgres'
+               }]))
+    def test_schema_get_again(self):
+        ret = postgres.schema_get(
+            'template1',
+            'pg_toast'
+        )
+        self.assertFalse(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.schema_exists',
+           Mock(return_value=False))
+    def test_schema_create(self):
+        postgres.schema_create(
+            'maint_db',
+            'testschema',
+            user='user',
+            db_host='testhost',
+            db_port='testport',
+            db_user='testuser',
+            db_password='testpassword'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'CREATE SCHEMA "testschema"',
+            db_name='maint_db', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres.schema_exists',
+           Mock(return_value=True))
+    def test_schema_create2(self):
+        ret = postgres.schema_create('test_db',
+                                     'test_schema',
+                                     user='user',
+                                     db_host='test_host',
+                                     db_port='test_port',
+                                     db_user='test_user',
+                                     db_password='test_password')
+        self.assertFalse(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.schema_exists',
+           Mock(return_value=True))
+    def test_schema_remove(self):
+        postgres.schema_remove(
+            'maint_db',
+            'testschema',
+            user='user',
+            db_host='testhost',
+            db_port='testport',
+            db_user='testuser',
+            db_password='testpassword'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'DROP SCHEMA "testschema"',
+            db_name='maint_db', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres.schema_exists',
+           Mock(return_value=False))
+    def test_schema_remove2(self):
+        ret = postgres.schema_remove('test_db',
+                                     'test_schema',
+                                     user='user',
+                                     db_host='test_host',
+                                     db_port='test_port',
+                                     db_user='test_user',
+                                     db_password='test_password')
+        self.assertFalse(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_list_language_csv}))
+    def test_language_list(self):
+        '''
+        Test language listing
+        '''
+        ret = postgres.language_list(
+            'testdb',
+            user='testuser',
+            host='testhost',
+            port='testport',
+            password='foo'
+        )
+        self.assertDictEqual(ret,
+                             {'c': 'c',
+                              'internal': 'internal',
+                              'plpgsql': 'plpgsql',
+                              'sql': 'sql'}
+        )
+
+    @patch('salt.modules.postgres._run_psql',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.psql_query',
+           Mock(return_value=[
+               {'Name': 'internal'},
+               {'Name': 'c'},
+               {'Name': 'sql'},
+               {'Name': 'plpgsql'}])
+           )
+    @patch('salt.modules.postgres.language_exists',
+           Mock(return_value=True))
+    def test_language_exists(self):
+        '''
+        Test language existence check
+        '''
+        ret = postgres.language_exists('sql', 'testdb')
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.language_exists',
+           Mock(return_value=False))
+    def test_language_create(self):
+        '''
+        Test language creation - does not exist in db
+        '''
+        postgres.language_create(
+            'plpythonu',
+            'testdb',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'CREATE LANGUAGE plpythonu',
+            db_name='testdb', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres.language_exists',
+           Mock(return_value=True))
+    def test_language_create_exists(self):
+        '''
+        Test language creation - already exists in db
+        '''
+        ret = postgres.language_create(
+            'plpythonu',
+            'testdb',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertFalse(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.language_exists',
+           Mock(return_value=True))
+    def test_language_remove(self):
+        '''
+        Test language removal - exists in db
+        '''
+        postgres.language_remove(
+            'plpgsql',
+            'testdb',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        postgres._psycopg_run_command.assert_called_once_with(
+            'DROP LANGUAGE plpgsql',
+            db_name='testdb', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres.language_exists',
+           Mock(return_value=False))
+    def test_language_remove_non_exist(self):
+        '''
+        Test language removal - does not exist in db
+        '''
+        ret = postgres.language_remove(
+            'plpgsql',
+            'testdb',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertFalse(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_privileges_list_table_csv}))
+    def test_privileges_list_table(self):
+        '''
+        Test privilege listing on a table
+        '''
+        ret = postgres.privileges_list(
+            'awl',
+            'table',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        expected = {
+            "bayestest": {
+                "INSERT": False,
+                "UPDATE": False,
+                "SELECT": False,
+                "DELETE": False,
+            },
+            "baruwa": {
+                "INSERT": True,
+                "TRUNCATE": True,
+                "UPDATE": True,
+                "TRIGGER": True,
+                "REFERENCES": True,
+                "SELECT": True,
+                "DELETE": True,
+            },
+            "baruwatest": {
+                "INSERT": False,
+                "TRUNCATE": False,
+                "UPDATE": False,
+                "TRIGGER": False,
+                "REFERENCES": False,
+                "SELECT": False,
+                "DELETE": False,
+            },
+        }
+        self.assertDictEqual(ret, expected)
+
+        postgres._psycopg_run_command.assert_called_once_with(
+            ("COPY (SELECT relacl AS name FROM pg_catalog.pg_class c "
+             "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+             "WHERE nspname = 'public' AND relname = 'awl' AND relkind = 'r' "
+             "ORDER BY relname) TO STDOUT WITH CSV HEADER"),
+            db_name='db_name', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_privileges_list_group_csv}))
+    def test_privileges_list_group(self):
+        '''
+        Test privilege listing on a group
+        '''
+        ret = postgres.privileges_list(
+            'admin',
+            'group',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        expected = {
+            'baruwa': False,
+            'baruwatest': False,
+            'baruwatest2': True,
+        }
+        self.assertDictEqual(ret, expected)
+
+        postgres._psycopg_run_command.assert_called_once_with(
+            ("COPY (SELECT rolname, admin_option "
+             "FROM pg_catalog.pg_auth_members m JOIN pg_catalog.pg_roles r "
+             "ON m.member=r.oid WHERE m.roleid IN (SELECT oid FROM "
+             "pg_catalog.pg_roles WHERE rolname='admin') ORDER BY rolname) "
+             "TO STDOUT WITH CSV HEADER"),
+            db_name='db_name', host='testhost', port='testport',
+            password='testpassword', user='testuser'
+        )
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_privileges_list_table_csv}))
+    def test_has_privileges_on_table(self):
+        '''
+        Test privilege checks on table
+        '''
+        ret = postgres.has_privileges(
+            'baruwa',
+            'awl',
+            'table',
+            'SELECT,INSERT',
+            grant_option=True,
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertTrue(ret)
+
+        ret = postgres.has_privileges(
+            'baruwa',
+            'awl',
+            'table',
+            'ALL',
+            grant_option=True,
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertTrue(ret)
+
+        ret = postgres.has_privileges(
+            'bayestest',
+            'awl',
+            'table',
+            'SELECT,INSERT,TRUNCATE',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertFalse(ret)
+
+        ret = postgres.has_privileges(
+            'bayestest',
+            'awl',
+            'table',
+            'SELECT,INSERT',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertTrue(ret)
+
+    @patch('salt.modules.postgres._psycopg_run_command',
+           Mock(return_value={'retcode': 0, 'stdout': test_privileges_list_group_csv}))
+    def test_has_privileges_on_group(self):
+        '''
+        Test privilege checks on group
+        '''
+        ret = postgres.has_privileges(
+            'baruwa',
+            'admin',
+            'group',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertTrue(ret)
+
+        ret = postgres.has_privileges(
+            'baruwa',
+            'admin',
+            'group',
+            grant_option=True,
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertFalse(ret)
+
+        ret = postgres.has_privileges(
+            'tony',
+            'admin',
+            'group',
+            maintenance_db='db_name',
+            runas='user',
+            host='testhost',
+            port='testport',
+            user='testuser',
+            password='testpassword'
+        )
+        self.assertFalse(ret)
+
+    def test_privileges_grant_table(self):
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=False)):
+                postgres.privileges_grant(
+                    'baruwa',
+                    'awl',
+                    'table',
+                    'ALL',
+                    grant_option=True,
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'GRANT ALL ON TABLE public.awl TO baruwa WITH GRANT OPTION',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=False)):
+                postgres.privileges_grant(
+                    'baruwa',
+                    'awl',
+                    'table',
+                    'ALL',
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'GRANT ALL ON TABLE public.awl TO baruwa',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+    def test_privileges_grant_group(self):
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=False)):
+                postgres.privileges_grant(
+                    'baruwa',
+                    'admins',
+                    'group',
+                    grant_option=True,
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'GRANT admins TO baruwa WITH ADMIN OPTION',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=False)):
+                postgres.privileges_grant(
+                    'baruwa',
+                    'admins',
+                    'group',
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'GRANT admins TO baruwa',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+    def test_privileges_revoke_table(self):
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=True)):
+                postgres.privileges_revoke(
+                    'baruwa',
+                    'awl',
+                    'table',
+                    'ALL',
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'REVOKE ALL ON TABLE public.awl FROM baruwa',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+    def test_privileges_revoke_group(self):
+        with patch('salt.modules.postgres._psycopg_run_command', Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges', Mock(return_value=True)):
+                postgres.privileges_revoke(
+                    'baruwa',
+                    'admins',
+                    'group',
+                    maintenance_db='db_name',
+                    runas='user',
+                    host='testhost',
+                    port='testport',
+                    user='testuser',
+                    password='testpassword'
+                )
+                postgres._psycopg_run_command.assert_called_once_with(
+                    'REVOKE admins FROM baruwa',
+                    db_name='db_name', host='testhost', port='testport',
+                    password='testpassword', user='testuser'
+                )
+
+    @patch('salt.modules.postgres._run_initdb',
+           Mock(return_value={'retcode': 0}))
+    @patch('salt.modules.postgres.datadir_exists',
+           Mock(return_value=False))
+    def test_datadir_init(self):
+        '''
+        Test Initializing a postgres data directory
+        '''
+        name = '/var/lib/pgsql/data'
+        ret = postgres.datadir_init(
+            name,
+            user='postgres',
+            password='test',
+            runas='postgres')
+        postgres._run_initdb.assert_called_once_with(
+            name,
+            auth='password',
+            encoding='UTF8',
+            locale=None,
+            password='test',
+            runas='postgres',
+            user='postgres',
+        )
+        self.assertTrue(ret)
+
+    @patch('os.path.isfile',
+           Mock(return_value=True))
+    def test_datadir_exists(self):
+        '''
+        Test Checks if postgres data directory has been initialized
+        '''
+        name = '/var/lib/pgsql/data'
+        ret = postgres.datadir_exists(name)
+        self.assertTrue(ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+
+    run_tests(PostgresTestCase, needs_daemon=False)


### PR DESCRIPTION
Add functionality to use psycopg2 to perform db operations on a postg…res database when available, allowing caching of connections across a salt state. Add functions to be able to run any command and any script on a database.

@mbirtwell